### PR TITLE
30 Feature: Add CRUD Endpoints to CategoryController 

### DIFF
--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/controllers/CategoryController.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/controllers/CategoryController.java
@@ -1,2 +1,59 @@
-package com.team_lightyear.WellCoffeeInventoryAPI.controllers;public class CategoryController {
+package com.team_lightyear.WellCoffeeInventoryAPI.controllers;
+
+import com.team_lightyear.WellCoffeeInventoryAPI.models.Category;
+import com.team_lightyear.WellCoffeeInventoryAPI.services.CategoryService;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/category")
+public class CategoryController {
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @PostMapping("/new")
+    public Category createCategory(@RequestBody Category category) {
+        return categoryService.createCategory(category);
+    }
+
+    @GetMapping("/all")
+    public List<Category> getAllCategories() {
+        return categoryService.getAllCategories();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getCategoryById(@PathVariable int id) {
+        Optional<Category> category = categoryService.getCategoryById(id);
+        if (category == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(category);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<?> updateCategory(@PathVariable int id, @RequestBody Category category) {
+        Category updatedCategory = categoryService.updateCategory(id, category);
+
+        if (updatedCategory == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+        return ResponseEntity.ok(updatedCategory);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteCategory(@PathVariable int id) {
+        try {
+            categoryService.deleteCategory(id);
+            return new ResponseEntity<>("Category with ID " + id + " deleted successfully", HttpStatus.OK);
+        } catch (EntityNotFoundException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+        }
+    }
 }

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/controllers/CategoryController.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/controllers/CategoryController.java
@@ -31,18 +31,18 @@ public class CategoryController {
     @GetMapping("/{id}")
     public ResponseEntity<?> getCategoryById(@PathVariable int id) {
         Optional<Category> category = categoryService.getCategoryById(id);
-        if (category == null) {
-            return ResponseEntity.notFound().build();
+        if (category.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Category with ID " + id + " not found");
         }
         return ResponseEntity.ok(category);
     }
 
     @PatchMapping("/{id}")
     public ResponseEntity<?> updateCategory(@PathVariable int id, @RequestBody Category category) {
-        Category updatedCategory = categoryService.updateCategory(id, category);
+        Optional<Category> updatedCategory = categoryService.updateCategory(id, category);
 
-        if (updatedCategory == null) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        if (updatedCategory.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Category with ID " + id + " not found");
         }
         return ResponseEntity.ok(updatedCategory);
     }
@@ -51,9 +51,10 @@ public class CategoryController {
     public ResponseEntity<?> deleteCategory(@PathVariable int id) {
         try {
             categoryService.deleteCategory(id);
-            return new ResponseEntity<>("Category with ID " + id + " deleted successfully", HttpStatus.OK);
+            return ResponseEntity.ok("Category with ID " + id + " deleted successfully");
         } catch (EntityNotFoundException e) {
-            return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }
     }
+
 }

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/controllers/CategoryController.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/controllers/CategoryController.java
@@ -1,0 +1,2 @@
+package com.team_lightyear.WellCoffeeInventoryAPI.controllers;public class CategoryController {
+}

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/models/Category.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/models/Category.java
@@ -24,8 +24,7 @@ public class Category {
     @Size(min = 3, max = 50, message = "Must be between 3 and 50 characters")
     private String name;
 
-    @OneToMany(cascade = CascadeType.ALL) // This makes sure operations like saving or deleting a category will also affect associated items
-    @JoinColumn(name = "category_id")
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL) // This makes sure operations like saving or deleting a category will also affect associated items
     private final List<Item> items = new ArrayList<>();
 
     private LocalDateTime dateCreated;

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/models/Category.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/models/Category.java
@@ -47,6 +47,10 @@ public class Category {
         return dateCreated;
     }
 
+    public void setDateCreated(LocalDateTime dateCreated) {
+        this.dateCreated = dateCreated;
+    }
+
     public String getName() {
         return name;
     }

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/models/Item.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/models/Item.java
@@ -27,6 +27,7 @@ public class Item {
     private String description;
 
     @ManyToOne
+    @JoinColumn(name = "category_id")
     private Category category;
 
     // No-argument constructor, required by JPA

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/services/CategoryService.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/services/CategoryService.java
@@ -33,16 +33,12 @@ public class CategoryService {
         return categoryRepository.findById(id);
     }
 
-    public Category updateCategory(int id, Category category) {
-        Optional<Category> optionalCategory = categoryRepository.findById(id);
-        if (optionalCategory.isPresent()) {
-            Category existingCategory = optionalCategory.get();
-
-            existingCategory.setName(category.getName());
-
+    public Optional<Category> updateCategory(int id, Category newCategory) {
+        return categoryRepository.findById(id).map(existingCategory -> {
+            existingCategory.setName(newCategory.getName());
+            existingCategory.setDateCreated(LocalDateTime.now());
             return categoryRepository.save(existingCategory);
-        }
-        return null;
+        });
     }
 
     public void deleteCategory(int id) {

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/services/CategoryService.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/services/CategoryService.java
@@ -1,6 +1,14 @@
 package com.team_lightyear.WellCoffeeInventoryAPI.services;
 
+import com.team_lightyear.WellCoffeeInventoryAPI.models.Category;
+import com.team_lightyear.WellCoffeeInventoryAPI.repositories.CategoryRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Created by Deanne Chae
@@ -8,4 +16,39 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class CategoryService {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    public Category createCategory(Category category) {
+        category.setDateCreated(LocalDateTime.now());
+        return categoryRepository.save(category);
+    }
+
+    public List<Category> getAllCategories() {
+        return categoryRepository.findAll();
+    }
+
+    public Optional<Category> getCategoryById(int id) {
+        return categoryRepository.findById(id);
+    }
+
+    public Category updateCategory(int id, Category category) {
+        Optional<Category> optionalCategory = categoryRepository.findById(id);
+        if (optionalCategory.isPresent()) {
+            Category existingCategory = optionalCategory.get();
+
+            existingCategory.setName(category.getName());
+
+            return categoryRepository.save(existingCategory);
+        }
+        return null;
+    }
+
+    public void deleteCategory(int id) {
+        if(!categoryRepository.existsById(id)) {
+            throw new EntityNotFoundException("Category with ID " + id + " not found");
+        }
+        categoryRepository.deleteById(id);
+    }
 }


### PR DESCRIPTION
This PR introduces CRUD endpoints to the 'CategoryController' by utilizing the 'CategoryService'. 

Changes:
- Refactored the relationship between 'Category' and 'Item' entities
- Added a setter method in the 'Category' entity for the 'dateCreated' field
- Added CRUD methods/logic in the 'CategoryService'
- Added endpoints in the 'CategoryController'

Testing:
- Run the application, 'WellCoffeeInventoryAPI [bootRun]'
- Connect to MySQL
- Test API endpoints using Postman
- Verify changes in the database

Postman Example:

POST: http://localhost:8080/api/category/new, 
- Select 'Body' -> 'raw' -> 'JSON', then input '{ "name": "Coffee" }'

GET: http://localhost:8080/api/category/all OR http://localhost:8080/api/category/1

PATCH: http://localhost:8080/api/category/1, 
- Select 'Body' -> 'raw' -> 'JSON', then input '{ "name": "Tea" }'

DELETE: http://localhost:8080/api/category/1
