### PR TITLE
36 Feature: Add CRUD Endpoints for Item Entity 

### DIFF
--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/controllers/CategoryController.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/controllers/CategoryController.java
@@ -38,13 +38,13 @@ public class CategoryController {
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<?> updateCategory(@PathVariable int id, @RequestBody Category category) {
-        Optional<Category> updatedCategory = categoryService.updateCategory(id, category);
-
-        if (updatedCategory.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Category with ID " + id + " not found");
+    public ResponseEntity<?> updateCategory(@PathVariable int id, @RequestBody Category categoryDetails) {
+        try {
+            Category updatedCategory = categoryService.updateCategory(id, categoryDetails);
+            return ResponseEntity.ok(updatedCategory);
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }
-        return ResponseEntity.ok(updatedCategory);
     }
 
     @DeleteMapping("/{id}")

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/controllers/ItemController.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/controllers/ItemController.java
@@ -1,0 +1,68 @@
+package com.team_lightyear.WellCoffeeInventoryAPI.controllers;
+
+import com.team_lightyear.WellCoffeeInventoryAPI.models.Item;
+import com.team_lightyear.WellCoffeeInventoryAPI.services.CategoryService;
+import com.team_lightyear.WellCoffeeInventoryAPI.services.ItemService;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/item")
+public class ItemController {
+
+    @Autowired
+    private ItemService itemService;
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @PostMapping("/new")
+    public ResponseEntity<?> createItem(@RequestParam int categoryId, @RequestBody Item item) {
+        try {
+            Item createdItem = itemService.createItem(categoryId, item);
+            return ResponseEntity.status(HttpStatus.CREATED).body(createdItem);
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    @GetMapping("/all")
+    public List<Item> getAllItems() {
+        return itemService.getAllItems();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getItemById(@PathVariable int id) {
+        Optional<Item> item = itemService.getItemById(id);
+        if (item.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Item with ID " + id + " not found");
+        }
+        return ResponseEntity.ok(item);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<?> updateItem(@PathVariable int id, @RequestBody Item itemDetails) {
+        try {
+            Item updatedItem = itemService.updateItem(id, itemDetails);
+            return ResponseEntity.ok(updatedItem);
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteItem(@PathVariable int id) {
+        try {
+            itemService.deleteItem(id);
+            return ResponseEntity.ok("Item with ID " + id + " deleted successfully");
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+}

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/models/Category.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/models/Category.java
@@ -1,5 +1,6 @@
 package com.team_lightyear.WellCoffeeInventoryAPI.models;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -24,7 +25,8 @@ public class Category {
     @Size(min = 3, max = 50, message = "Must be between 3 and 50 characters")
     private String name;
 
-    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL) // This makes sure operations like saving or deleting a category will also affect associated items
+    @OneToMany(mappedBy = "category")
+    @JsonManagedReference // Prevents infinite recursion
     private final List<Item> items = new ArrayList<>();
 
     private LocalDateTime dateCreated;

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/models/Item.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/models/Item.java
@@ -1,5 +1,6 @@
 package com.team_lightyear.WellCoffeeInventoryAPI.models;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -28,6 +29,7 @@ public class Item {
 
     @ManyToOne
     @JoinColumn(name = "category_id")
+    @JsonBackReference // Prevents infinite recursion
     private Category category;
 
     // No-argument constructor, required by JPA

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/services/CategoryService.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/services/CategoryService.java
@@ -33,12 +33,13 @@ public class CategoryService {
         return categoryRepository.findById(id);
     }
 
-    public Optional<Category> updateCategory(int id, Category newCategory) {
-        return categoryRepository.findById(id).map(existingCategory -> {
-            existingCategory.setName(newCategory.getName());
-            existingCategory.setDateCreated(LocalDateTime.now());
-            return categoryRepository.save(existingCategory);
-        });
+    public Category updateCategory(int id, Category categoryDetails) {
+        Category existingCategory = categoryRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Category with ID " + id + " not found"));
+
+        existingCategory.setName(categoryDetails.getName());
+        existingCategory.setDateCreated(LocalDateTime.now());
+        return categoryRepository.save(existingCategory);
     }
 
     public void deleteCategory(int id) {

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/services/ItemService.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/services/ItemService.java
@@ -1,10 +1,83 @@
 package com.team_lightyear.WellCoffeeInventoryAPI.services;
 
+import com.team_lightyear.WellCoffeeInventoryAPI.models.Category;
+import com.team_lightyear.WellCoffeeInventoryAPI.models.Item;
+import com.team_lightyear.WellCoffeeInventoryAPI.repositories.CategoryRepository;
+import com.team_lightyear.WellCoffeeInventoryAPI.repositories.ItemRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Created by Deanne Chae
  */
 @Service
 public class ItemService {
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    public Item createItem(int categoryId, Item item) {
+        /* '.orElseThrow()' is another/more current method of working with 'Optional'
+        This approach will either get the category or throw an exception */
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new EntityNotFoundException("Category with ID " + categoryId + " not found"));
+
+        // If no exception is thrown, the category will be assigned and the item saved
+        item.setCategory(category);
+        return itemRepository.save(item);
+    }
+
+    public List<Item> getAllItems() {
+        return itemRepository.findAll();
+    }
+
+    public Optional<Item> getItemById(int id) {
+        return itemRepository.findById(id);
+    }
+
+    public Item updateItem(int id, Item itemDetails) {
+        Item item = itemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Item with ID " + id + " not found"));
+
+        /* The if statements will check to see if each field is presented with data
+        Any field without a value will remain the same */
+        if (itemDetails.getName() != null) {
+            item.setName(itemDetails.getName());
+        }
+        if (itemDetails.getQuantity() != null) {
+            item.setQuantity(itemDetails.getQuantity());
+        }
+        if (itemDetails.getPrice() != null) {
+            item.setPrice(itemDetails.getPrice());
+        }
+        if (itemDetails.getLocation() != null) {
+            item.setLocation(itemDetails.getLocation());
+        }
+        if (itemDetails.getDescription() != null) {
+            item.setDescription(itemDetails.getDescription());
+        }
+        if (itemDetails.getCategory() != null) {
+            // If the category field gets assigned a new value we need to make sure it exists in the database
+            int categoryId = itemDetails.getCategory().getId();
+            Category category = categoryRepository.findById(categoryId)
+                    .orElseThrow(() -> new EntityNotFoundException("Category with ID " + categoryId + " not found"));
+            item.setCategory(category);
+        }
+
+        return itemRepository.save(item);
+    }
+
+    public void deleteItem(int id) {
+        if(!itemRepository.existsById(id)) {
+            throw new EntityNotFoundException("Item with ID " + id + " not found");
+        }
+        itemRepository.deleteById(id);
+    }
 }


### PR DESCRIPTION
This PR mainly introduces CRUD endpoints to the 'ItemController'. The 'ItemService' was also updated with the necessary methods. A few minor issues were also corrected.

Changes:
- Removed unnecessary code such as 'cascade' from the @OneToMany annotation in Category
- Added @JsonManagedReference and @JsonBackReference annotations to 'Category' and 'Item' respectively to avoid infinite recursion
- I had to edit the 'updateCategory' method to return an actual Category object instead of Optional (this was causing a chain reaction of issues when trying to create the methods and endpoints for Item)
- Completed all the methods for 'ItemService'
- Created a new 'ItemController' with endpoints

Testing w/ Postman:
- Add a new category before you start
- Verify changes in MySQL with each request 

POST: http://localhost:8080/api/item/new?categoryId=1
- Select 'Body' -> 'raw' -> 'JSON', then input ->
{
    "name": "Espresso",
    "quantity": 15,
    "price": 2.99,
    "location": "Shelf A",
    "description": "Espresso beans"
}

GET: http://localhost:8080/api/item/all OR http://localhost:8080/api/item/1

PATCH: http://localhost:8080/api/item/1
- Select 'Body' -> 'raw' -> 'JSON', then input ->
{
    "name": "Cold Brew",
    "description": "Concentrate"
}

DELETE: http://localhost:8080/api/item/1