### PR TITLE
74-issue-fix-delete-item-functionality

### DIFF
--- a/Well-Coffee-UI/src/components/home/CategoryDisplay.jsx
+++ b/Well-Coffee-UI/src/components/home/CategoryDisplay.jsx
@@ -10,14 +10,20 @@ const CategoryDisplay = ({ categories, fetchCategories }) => {
 
   const handleDeleteItem = async (itemId) => {
     try {
-      await deleteItem(itemId);
-      setMessage("Item deleted successfully!");
+      const response = await deleteItem(itemId);
+      if(response.status === 200) {
+        setMessage("Item deleted successfully!");
+      }
       setTimeout(() => {
         setMessage("");
       }, 1500);
       fetchCategories();
     } catch (error) {
-      setMessage("There was an error deleting the item. Please try again.");
+      if (error.response && error.response.status === 400) {
+        setMessage("This item is associated with an invoice and cannot be deleted at this time.")
+      } else {
+        setMessage("There was an error deleting the item. Please try again.");
+      }
       setTimeout(() => {
         setMessage("");
       }, 1500);

--- a/Well-Coffee-UI/src/services/ItemService.js
+++ b/Well-Coffee-UI/src/services/ItemService.js
@@ -35,7 +35,7 @@ export const updateItem = async (itemId, itemData) => {
 export const deleteItem = async (itemId) => {
   try {
     const response = await axios.delete(`${BASEAPIURL}/${itemId}`);
-    return response.data;
+    return response;
   } catch (error) {
     console.error("There was an error deleting the item", error);
     throw error;

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/controllers/ItemController.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/controllers/ItemController.java
@@ -83,6 +83,8 @@ public class ItemController {
             return ResponseEntity.ok("Item with ID " + id + " deleted successfully");
         } catch (EntityNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("The item with ID " + id + " is linked to other records and cannot be deleted at this time.");
         }
     }
 }

--- a/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/services/ItemService.java
+++ b/WellCoffeeInventoryAPI/src/main/java/com/team_lightyear/WellCoffeeInventoryAPI/services/ItemService.java
@@ -9,6 +9,7 @@ import com.team_lightyear.WellCoffeeInventoryAPI.repositories.InvoiceRepository;
 import com.team_lightyear.WellCoffeeInventoryAPI.repositories.ItemRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -109,7 +110,11 @@ public class ItemService {
         if(!itemRepository.existsById(id)) {
             throw new EntityNotFoundException("Item with ID " + id + " not found");
         }
-        itemRepository.deleteById(id);
+        try {
+            itemRepository.deleteById(id);
+        } catch (DataIntegrityViolationException e) {
+            throw new RuntimeException("Cannot delete item with ID " + id + " due to foreign key constraints");
+        }
     }
     
     //Adds invoice to the list of invoices in the Item


### PR DESCRIPTION
Added more specific error handling for the 'deleteItem' endpoint due to the foreign key constraints with related entities.

The error/alert message when trying to delete an item that's been ordered and part of an invoice: **(wellcoffee.invoice_ordered_items, CONSTRAINT FKnxxyklugha8ccnitcns8jgmjd FOREIGN KEY (ordered_items_id) REFERENCES ordered_item (id))**

This is happening because of the relationship between 'item' and 'ordered_item' and the tables that are being created around them. These tables ('ordered_item' and 'invoice_ordered_items') have a foreign key column of 'item_id' or 'ordered_items_id'. But this is a good thing! It protects our database from deleting items that are associated to other tables. Thought it would be a good idea to at least specify the exact issue in the console!
